### PR TITLE
Fix scrolling when using -webkit-overflow-scrolling:touch;

### DIFF
--- a/src/slinky.js
+++ b/src/slinky.js
@@ -42,7 +42,7 @@
             if (header.position != position) {
               header.$parent.css('paddingTop', header.height);
               header.$
-                .css('position', 'absolute')
+                .css('position', 'fixed')
                 .css(position, header[position])
                 .css(position == 'top' ? 'bottom' : 'top', '');
               header.position = position;


### PR DESCRIPTION
This is a great plugin, but I want my mobile visitors to still get the smooth scrolling that `-webkit-overflow-scrolling:touch;` provides. I applied that to the scrolling element's CSS, but it then made the headers not update properly and generally became glitchy.

I found that a quick fix to this was to have this set the headers to be `position:fixed;` rather than `position:absolute;`. The scrolling is now perfectly smooth and the headers still attach themselves as you'd expect.

I'd like to see this implemented in the main distribution of this since I'm sure other people will want to have sticky headers and smooth scrolling.

Thanks!