### PR TITLE
Search for MutationObserver in window

### DIFF
--- a/src/slinky.js
+++ b/src/slinky.js
@@ -108,7 +108,7 @@
       // units where used anywhere.
       $(window).on('resize.' + pluginName, init);
 
-      var MutationObserver = MutationObserver || window.WebKitMutationObserver;
+      var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
       if (MutationObserver) {
         var observer = new MutationObserver(init);
         observer.observe($scroller[0], {


### PR DESCRIPTION
without searching the window object, the latest Firefox (37.0.1, testing on osx)  isn't registering MutationObserver (it's undefined). 

[demo: https://jsfiddle.net/u19xyL9n/4/](https://jsfiddle.net/u19xyL9n/4/)

This doesn't appear to be an issue in the other major browsers